### PR TITLE
Handle cases where `[package.metadata.x]` isn't present

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,12 +11,12 @@ struct Cargo {
 
 #[derive(Deserialize)]
 struct Package {
-    metadata: Metadata,
+    metadata: Option<Metadata>,
 }
 
 #[derive(Deserialize)]
 struct Metadata {
-    x: Xconf,
+    x: Option<Xconf>,
 }
 
 pub type Xconf = HashMap<String, String>;
@@ -71,7 +71,13 @@ fn cargo() -> Result<Xconf, Error> {
 
     let cargo_toml: Cargo = toml::from_str(&conf_string)?;
 
-    Ok(cargo_toml.package.metadata.x)
+    Ok(
+        if let Some(Metadata { x: Some(x) }) = cargo_toml.package.metadata {
+            x
+        } else {
+            HashMap::new()
+        },
+    )
 }
 
 pub fn get() -> Result<Xconf, Error> {


### PR DESCRIPTION
cargo-x throws errors when `[package.metadata.x]` isn't present. Based on the README this doesn't seem to be the intended behavior but if it is please ignore this PR.